### PR TITLE
AWS' SDK concerns for cached credentials should not be handled by the logger

### DIFF
--- a/src/lua/api-gateway/logger/BufferedAsyncLogger.lua
+++ b/src/lua/api-gateway/logger/BufferedAsyncLogger.lua
@@ -217,12 +217,7 @@ function AsyncLogger:getLogsFromSharedDict()
                 and metric ~= "pendingTimers_lock"
                 and metric ~= "flush_lock"
                 and metric ~= "lastFlushTimestamp"
-                and metric ~= "throughput_counter"
-                and metric ~= "AccessKeyId"
-                and metric ~= "SecretAccessKey"
-                and metric ~= "Token"
-                and metric ~= "ExpireAt"
-                and metric ~= "ExpireAtTimestamp") then
+                and metric ~= "throughput_counter") then
             local v = allMetrics:get(metric)
             if (v ~= nil and metric ~= nil) then
                 logs[metric] = v


### PR DESCRIPTION
… as they're handled by the aws sdk.

This PR removes some fields that are specific to how [api-gateway-aws](https://github.com/adobe-apiplatform/api-gateway-aws) caches the credentials:
* https://github.com/adobe-apiplatform/api-gateway-aws/blob/master/src/lua/api-gateway/aws/AWSIAMCredentials.lua#L89
* https://github.com/adobe-apiplatform/api-gateway-aws/blob/master/src/lua/api-gateway/aws/AWSSTSCredentials.lua#L155

These fields should be out of scope for the logger module itself.